### PR TITLE
add include schema privileges for views

### DIFF
--- a/dbt/include/vertica/macros/materializations/models/view/create_or_replace_view.sql
+++ b/dbt/include/vertica/macros/materializations/models/view/create_or_replace_view.sql
@@ -2,7 +2,7 @@
   {% set sql_header = config.get('sql_header', none) %}
 
   {{ sql_header if sql_header is not none }}
-  create or replace view {{ relation }} as (
+  create or replace view {{ relation }} include schema privileges as (
     {{ sql }}
   );
 {% endmacro %}

--- a/dbt/include/vertica/macros/materializations/models/view/create_view_as.sql
+++ b/dbt/include/vertica/macros/materializations/models/view/create_view_as.sql
@@ -7,7 +7,7 @@
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  create view {{ relation }} as (
+  create view {{ relation }} include schema privileges as (
     {{ sql }}
   );
 {%- endmacro %}

--- a/tests/integration.dbtspec
+++ b/tests/integration.dbtspec
@@ -76,14 +76,14 @@ projects:
                 merge_columns = [ 'id', 'name' ]
               )
             }}
-            with incremental_data as 
+            with incremental_data as
             (
               select * from {{ source('raw', 'seed') }}
               {% if is_incremental() %}
               where id > (select max(id) from {{ this }})
               {% endif %}
-            ) 
-            select * from incremental_data  
+            )
+            select * from incremental_data
     facts:
       seed:
         length: 2
@@ -123,7 +123,7 @@ sequences:
   # Test the incremental merge based upon specific columns
   test_vertica_dbt_incremental_merge_columns:
     project: test_vertica_dbt_incremental_merge_columns
-    sequence: 
+    sequence:
       - type: dbt
         cmd: seed
       - type: run_results


### PR DESCRIPTION
Hello
We have a trouble, if we create view from service account in the vertica then view has other grants, not from schema.
So we decide to fix it in the adapter, because put alter with include privileges to the post-hook is bad decision, I think.