### PR TITLE
Fix dbt_valid_to bug for snapshots

### DIFF
--- a/tests/functional/adapter/unit_testing/test_types.py
+++ b/tests/functional/adapter/unit_testing/test_types.py
@@ -81,4 +81,4 @@ class BaseUnitTestingTypes:
 
 
 class TestVerticaUnitTestingTypes(BaseUnitTestingTypes):
-pass
+  pass


### PR DESCRIPTION
Macro vertica__snapshot_merge_sql.sql has hardcoding value 'DBT_INTERNAL_DEST.dbt_valid_to' equal null in 'where' block, if we change 'dbt_valid_to_current' in project snapshot will not update dbt_valid_to_current column. 

This changes take correct 'dbt_valid_to_current' and put it in 'where' block.