### PR TITLE
Fix bug with dbt-valid-to-current

### DIFF
--- a/dbt/include/vertica/macros/materializations/snapshots/snapshot_merge.sql
+++ b/dbt/include/vertica/macros/materializations/snapshots/snapshot_merge.sql
@@ -6,12 +6,19 @@
       {%- set insert_cols_csv = get_quoted_csv(get_columns_in_relation(target) | map(attribute="name")) %}
   {% endif %}
 
+  {%- set dbt_valid_to = config.get('dbt_valid_to_current', 'null') -%}
+
   merge into {{ target }} as DBT_INTERNAL_DEST
   using {{ source }} as DBT_INTERNAL_SOURCE
   on DBT_INTERNAL_SOURCE.dbt_scd_id = DBT_INTERNAL_DEST.dbt_scd_id
 
   when matched
-    and DBT_INTERNAL_DEST.dbt_valid_to is null
+    and
+        {% if dbt_valid_to == 'null' %}
+          DBT_INTERNAL_DEST.dbt_valid_to is null
+        {% else %}
+          DBT_INTERNAL_DEST.dbt_valid_to = {{ dbt_valid_to }}
+        {% endif %}
     and DBT_INTERNAL_SOURCE.dbt_change_type in ('update', 'delete')
       then update
       set dbt_valid_to = DBT_INTERNAL_SOURCE.dbt_valid_to


### PR DESCRIPTION
Macro vertica__snapshot_merge_sql.sql has hardcoding value 'DBT_INTERNAL_DEST.dbt_valid_to' equal null in 'where' block, if we change 'dbt_valid_to_current' in project snapshot will not update dbt_valid_to_current column.

This changes take correct 'dbt_valid_to_current' and put it in 'where' block.