### PR TITLE
Added support for dbt-core 1.11

### DIFF
--- a/.github/workflows/vertica-test.yml
+++ b/.github/workflows/vertica-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8','3.9' ,'3.10', '3.11']
+        python-version: [ '3.9' ,'3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 - "Breaking changes" listed under a version may require action from end users.
 
 
+### 1.11.0
+=======
+#### Features:
+- Upgrade to support dbt-core v1.11
+- Bump `dbt-core` dependency to `1.11.12` and `dbt-tests-adapter` to `1.20.0`
+
+#### Breaking changes:
+- Dropped support for Python 3.8 (dbt-core 1.11 requires Python >= 3.9)
+
 ### 1.8.5
 =======
 #### Features:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ dbt-vertica has been developed using the following software and versions:
 * Vertica Server 23.4.0-0
 * Python 3.11
 * vertica-python client 1.3.1
-* dbt-core 1.8.5
-* dbt-tests-adapter 1.8.0
+* dbt-core 1.11.12
+* dbt-tests-adapter 1.20.0
 
 ## Supported Features
 ### dbt Core Features

--- a/dbt/adapters/vertica/__version__.py
+++ b/dbt/adapters/vertica/__version__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "1.8.5"
+version = "1.11.0"
 

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ import os
 import sys
 import re
 
-# require python 3.8 or newer
-if sys.version_info < (3, 8):
+# require python 3.9 or newer
+if sys.version_info < (3, 9):
     print("Error: dbt does not support this version of Python.")
-    print("Please upgrade to Python 3.8 or higher.")
+    print("Please upgrade to Python 3.9 or higher.")
     sys.exit(1)
 
 
@@ -78,7 +78,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-vertica"
-package_version = "1.8.6"
+package_version = "1.11.0"
 
 description = """Official vertica adapter plugin for dbt (data build tool)"""
 dbt_core_version = _get_dbt_core_version()
@@ -114,10 +114,10 @@ setup(
         ]
     },
     install_requires=[
-       'dbt-core==1.8.5',
+       'dbt-core==1.11.12',
         # "dbt-core~={}".format(dbt_core_version),
         'vertica-python>=1.1.0',
-        'dbt-tests-adapter==1.8.0',
+        'dbt-tests-adapter==1.20.0',
         'python-dotenv==0.21.1',
         'pytest>=8.3.2',
     ],
@@ -132,5 +132,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Operating System :: OS Independent"
     ],
-    python_requires=">=3.8.0",
+    python_requires=">=3.9.0",
 )

--- a/tests/functional/adapter/concurrency/test_concurrency.py
+++ b/tests/functional/adapter/concurrency/test_concurrency.py
@@ -344,4 +344,4 @@ class TestConcurenncyVertica(BaseConcurrency):
         check_table_does_not_exist(project.adapter, "invalid")
         check_table_does_not_exist(project.adapter, "skip")
 
-        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 TOTAL=7" in output
+        assert "PASS=5 WARN=0 ERROR=1 SKIP=1 NO-OP=0 TOTAL=7" in output


### PR DESCRIPTION
- Pinned dbt-core to 1.11.12 and dbt-tests-adapter to 1.20.0
- Bumped adapter version to 1.11.0
- Dropped Python 3.8 (dbt-core 1.11 requires >=3.9), added 3.12 to CI
- Fixed concurrency test for the new NO-OP field in run summary output
- Updated README tested versions and CHANGELOG